### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/deployment.yml
+++ b/.github/workflows/deployment.yml
@@ -1,3 +1,5 @@
+permissions:
+  contents: read
 name: Vercel Development Deployment
 
 env:


### PR DESCRIPTION
Potential fix for [https://github.com/InternetMaximalism/intmax2-docs/security/code-scanning/1](https://github.com/InternetMaximalism/intmax2-docs/security/code-scanning/1)

To fix the problem, add a `permissions` block to the workflow to explicitly set the minimal required permissions for the `GITHUB_TOKEN`. Since the workflow only checks out code and deploys to Vercel (with no GitHub write operations), the minimal permission required is `contents: read`. This can be set at the workflow level (applies to all jobs) or at the job level. The best practice is to add it at the top level, just after the `name` field, so all jobs inherit it unless overridden. No additional methods, imports, or definitions are needed.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
